### PR TITLE
Initialize LangGraph boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Instead of just Medium, publish to:
 
 ### Phase 1 (Weeks 1-2): Foundation
 - Set up LangGraph framework
+- Run `python medium_writer/langgraph_app.py` to verify the graph
 - Integrate primary LLM provider
 - Build basic content generation pipeline
 

--- a/medium_writer/langgraph_app.py
+++ b/medium_writer/langgraph_app.py
@@ -1,0 +1,32 @@
+# Basic LangGraph setup
+from langgraph.graph import Graph
+from langgraph.prebuilt import tools
+
+
+def plan_content(context: dict) -> dict:
+    """Simple planning step."""
+    context['plan'] = 'Write an article about Python tips.'
+    return context
+
+
+def generate_content(context: dict) -> dict:
+    """Generate content placeholder."""
+    plan = context.get('plan', '')
+    context['article'] = f"This is a draft generated from the plan: {plan}"
+    return context
+
+
+def build_graph() -> Graph:
+    g = Graph()
+    g.add_node('plan', plan_content)
+    g.add_node('generate', generate_content)
+    g.add_edge('plan', 'generate')
+    g.set_entry_point('plan')
+    g.set_finish_point('generate')
+    return g
+
+
+if __name__ == '__main__':
+    graph = build_graph()
+    result = graph.invoke({})
+    print(result['article'])


### PR DESCRIPTION
## Summary
- add simple LangGraph example
- mention how to run the example in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874329ea134832da7d1a9343fde8c89